### PR TITLE
remove unused variable from QUnit reporting code

### DIFF
--- a/reporting_QUnit.js
+++ b/reporting_QUnit.js
@@ -1,5 +1,4 @@
 var log = [];
-var testName;
  
 QUnit.done(function (test_results) {
   var tests = [];


### PR DESCRIPTION
Realized `testName` was unused because my jshint complained.